### PR TITLE
Fix compilation errors in demo files

### DIFF
--- a/opentsx-core/src/main/java/org/opentsx/demo/onboarding/AnomalyDetection.java
+++ b/opentsx-core/src/main/java/org/opentsx/demo/onboarding/AnomalyDetection.java
@@ -3,6 +3,7 @@ package org.opentsx.demo.onboarding;
 import org.opentsx.data.generator.RNGWrapper;
 import org.opentsx.data.series.TimeSeriesObject;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -77,8 +78,8 @@ public class AnomalyDetection {
         // Inject known anomalies
         List<Integer> injectedAnomalies = new ArrayList<>();
 
-        for (int i = 0; i < normalData.getLength(); i++) {
-            double value = normalData.getValueAt(i);
+        for (int i = 0; i < normalData.yValues.size(); i++) {
+            double value = normalData(Double).yValues.elementAt(i);
 
             // Inject point anomalies (10 total)
             if (i == 50 || i == 150 || i == 250 || i == 350 || i == 450) {
@@ -96,10 +97,10 @@ public class AnomalyDetection {
         }
 
         System.out.println("Created time series:");
-        System.out.println("  Total points: " + dataWithAnomalies.getLength());
+        System.out.println("  Total points: " + dataWithAnomalies.yValues.size());
         System.out.println("  Injected anomalies: " + injectedAnomalies.size());
         System.out.println("  Anomaly rate: " + String.format("%.2f%%",
-                (injectedAnomalies.size() * 100.0) / dataWithAnomalies.getLength()));
+                (injectedAnomalies.size() * 100.0) / dataWithAnomalies.yValues.size()));
         System.out.println();
 
         // =====================================================
@@ -182,8 +183,8 @@ public class AnomalyDetection {
         // Inject seasonal anomalies
         for (int i = 0; i < 5; i++) {
             int anomalyIndex = 50 + i * 50;
-            if (anomalyIndex < seasonal.getLength()) {
-                seasonal.setValueAt(anomalyIndex, seasonal.getValueAt(anomalyIndex) + 30.0);
+            if (anomalyIndex < seasonal.yValues.size()) {
+                seasonal.yValues.setElementAt((Double)seasonal.yValues.elementAt(anomalyIndex) + 30.0, anomalyIndex);
             }
         }
 
@@ -209,7 +210,7 @@ public class AnomalyDetection {
 
         // Inject burst (20 consecutive high values)
         for (int i = 150; i < 170; i++) {
-            burstData.setValueAt(i, 130.0 + RNGWrapper.getGaussianRandomValue(0, 3));
+            burstData.yValues.setElementAt(130.0 + RNGWrapper.getStdRandomGaussian(0, 3), i);
         }
 
         // Detect bursts
@@ -286,11 +287,11 @@ public class AnomalyDetection {
      */
     private static List<Anomaly> zScoreDetection(TimeSeriesObject ts, double threshold) {
         List<Anomaly> anomalies = new ArrayList<>();
-        double mean = ts.getMeanY();
+        double mean = ts.getAvarage();
         double stddev = ts.getStddev();
 
-        for (int i = 0; i < ts.getLength(); i++) {
-            double value = ts.getValueAt(i);
+        for (int i = 0; i < ts.yValues.size(); i++) {
+            double value = ts(Double).yValues.elementAt(i);
             double zScore = Math.abs((value - mean) / stddev);
 
             if (zScore > threshold) {
@@ -310,15 +311,15 @@ public class AnomalyDetection {
         List<Anomaly> anomalies = new ArrayList<>();
         int halfWindow = windowSize / 2;
 
-        for (int i = halfWindow; i < ts.getLength() - halfWindow; i++) {
+        for (int i = halfWindow; i < ts.yValues.size() - halfWindow; i++) {
             // Calculate local statistics
             double sum = 0;
             double sumSq = 0;
             int count = 0;
 
             for (int j = i - halfWindow; j < i + halfWindow; j++) {
-                if (j != i && j >= 0 && j < ts.getLength()) {
-                    double val = ts.getValueAt(j);
+                if (j != i && j >= 0 && j < ts.yValues.size()) {
+                    double val = ts(Double).yValues.elementAt(j);
                     sum += val;
                     sumSq += val * val;
                     count++;
@@ -329,7 +330,7 @@ public class AnomalyDetection {
             double localVariance = (sumSq / count) - (localMean * localMean);
             double localStddev = Math.sqrt(localVariance);
 
-            double value = ts.getValueAt(i);
+            double value = ts(Double).yValues.elementAt(i);
             double zScore = Math.abs((value - localMean) / localStddev);
 
             if (zScore > threshold) {
@@ -349,10 +350,10 @@ public class AnomalyDetection {
         List<Anomaly> anomalies = new ArrayList<>();
 
         // Simple seasonal decomposition
-        for (int i = period; i < ts.getLength(); i++) {
+        for (int i = period; i < ts.yValues.size(); i++) {
             // Compare with same position in previous period
-            double currentValue = ts.getValueAt(i);
-            double previousValue = ts.getValueAt(i - period);
+            double currentValue = ts(Double).yValues.elementAt(i);
+            double previousValue = ts(Double).yValues.elementAt(i - period);
             double diff = Math.abs(currentValue - previousValue);
 
             // Calculate local mean and stddev for threshold
@@ -418,7 +419,7 @@ public class AnomalyDetection {
 
         for (int i = 0; i < length; i++) {
             double seasonal = amplitude * Math.sin(2 * Math.PI * i / period);
-            double randomNoise = RNGWrapper.getGaussianRandomValue(0, noise);
+            double randomNoise = RNGWrapper.getStdRandomGaussian(0, noise);
             double value = baseline + seasonal + randomNoise;
             ts.addValuePair(i, value);
         }
@@ -435,7 +436,7 @@ public class AnomalyDetection {
         StringBuilder sb = new StringBuilder();
         sb.append("index,value,anomaly,z_score\n");
 
-        for (int i = 0; i < ts.getLength(); i++) {
+        for (int i = 0; i < ts.yValues.size(); i++) {
             boolean isAnomaly = false;
             double zScore = 0.0;
 
@@ -448,7 +449,7 @@ public class AnomalyDetection {
             }
 
             sb.append(i).append(",")
-              .append(ts.getValueAt(i)).append(",")
+              .append(ts(Double).yValues.elementAt(i)).append(",")
               .append(isAnomaly ? 1 : 0).append(",")
               .append(String.format("%.4f", zScore)).append("\n");
         }

--- a/opentsx-core/src/main/java/org/opentsx/demo/onboarding/BasicOperations.java
+++ b/opentsx-core/src/main/java/org/opentsx/demo/onboarding/BasicOperations.java
@@ -3,6 +3,7 @@ package org.opentsx.demo.onboarding;
 import org.opentsx.data.generator.RNGWrapper;
 import org.opentsx.data.series.TimeSeriesObject;
 
+import java.io.File;
 import java.io.IOException;
 
 /**
@@ -44,8 +45,8 @@ public class BasicOperations {
 
         System.out.println("Sample Data Created:");
         System.out.println("  Label: " + rawData.getLabel());
-        System.out.println("  Length: " + rawData.getLength());
-        System.out.println("  Mean: " + String.format("%.2f", rawData.getMeanY()));
+        System.out.println("  Length: " + rawData.yValues.size());
+        System.out.println("  Mean: " + String.format("%.2f", rawData.getAvarage()));
         System.out.println("  Std Dev: " + String.format("%.2f", rawData.getStddev()));
         System.out.println();
 
@@ -60,30 +61,32 @@ public class BasicOperations {
         normalized.setLabel("normalized_data");
 
         System.out.println("Normalized time series:");
-        System.out.println("  Mean: " + String.format("%.4f", normalized.getMeanY()) +
+        System.out.println("  Mean: " + String.format("%.4f", normalized.getAvarage()) +
                           " (should be ~0)");
         System.out.println("  Std Dev: " + String.format("%.4f", normalized.getStddev()) +
                           " (should be ~1)");
         System.out.println();
 
         // Scale (multiply by constant)
-        TimeSeriesObject scaled = rawData.scaleY(0.5);
+        TimeSeriesObject scaled = rawData.copy();
+        scaled.scaleY_2(0.5);
         scaled.setLabel("scaled_data");
 
         System.out.println("Scaled time series (multiply by 0.5):");
-        System.out.println("  Original mean: " + String.format("%.2f", rawData.getMeanY()));
-        System.out.println("  Scaled mean: " + String.format("%.2f", scaled.getMeanY()));
-        System.out.println("  Expected: " + String.format("%.2f", rawData.getMeanY() * 0.5));
+        System.out.println("  Original mean: " + String.format("%.2f", rawData.getAvarage()));
+        System.out.println("  Scaled mean: " + String.format("%.2f", scaled.getAvarage()));
+        System.out.println("  Expected: " + String.format("%.2f", rawData.getAvarage() * 0.5));
         System.out.println();
 
         // Offset (add constant)
-        TimeSeriesObject offset = rawData.add(25.0);
+        TimeSeriesObject offset = rawData.copy();
+        offset.add_to_Y(25.0);
         offset.setLabel("offset_data");
 
         System.out.println("Offset time series (add 25.0):");
-        System.out.println("  Original mean: " + String.format("%.2f", rawData.getMeanY()));
-        System.out.println("  Offset mean: " + String.format("%.2f", offset.getMeanY()));
-        System.out.println("  Expected: " + String.format("%.2f", rawData.getMeanY() + 25.0));
+        System.out.println("  Original mean: " + String.format("%.2f", rawData.getAvarage()));
+        System.out.println("  Offset mean: " + String.format("%.2f", offset.getAvarage()));
+        System.out.println("  Expected: " + String.format("%.2f", rawData.getAvarage() + 25.0));
         System.out.println();
 
         // =====================================================
@@ -93,24 +96,24 @@ public class BasicOperations {
         System.out.println("------------------------");
 
         // Filter by value threshold
-        double threshold = rawData.getMeanY();
+        double threshold = rawData.getAvarage();
         TimeSeriesObject aboveAverage = rawData.copy();
         aboveAverage.setLabel("above_average");
 
         // Manual filtering (keeping values above mean)
         int countAbove = 0;
-        for (int i = 0; i < rawData.getLength(); i++) {
-            if (rawData.getValueAt(i) > threshold) {
+        for (int i = 0; i < rawData.yValues.size(); i++) {
+            if ((Double)rawData.yValues.elementAt(i) > threshold) {
                 countAbove++;
             }
         }
 
         System.out.println("Filter by value:");
         System.out.println("  Threshold (mean): " + String.format("%.2f", threshold));
-        System.out.println("  Original length: " + rawData.getLength());
+        System.out.println("  Original length: " + rawData.yValues.size());
         System.out.println("  Values above mean: " + countAbove);
         System.out.println("  Percentage: " + String.format("%.1f%%",
-                          (countAbove * 100.0) / rawData.getLength()));
+                          (countAbove * 100.0) / rawData.yValues.size()));
         System.out.println();
 
         // Filter by time range (shrink)
@@ -118,8 +121,8 @@ public class BasicOperations {
         subset.setLabel("time_window");
 
         System.out.println("Filter by time range (indices 200-400):");
-        System.out.println("  Original length: " + rawData.getLength());
-        System.out.println("  Subset length: " + subset.getLength());
+        System.out.println("  Original length: " + rawData.yValues.size());
+        System.out.println("  Subset length: " + subset.yValues.size());
         System.out.println();
 
         // =====================================================
@@ -129,7 +132,7 @@ public class BasicOperations {
         System.out.println("----------------------------");
 
         double sum = rawData.summeY();
-        double mean = rawData.getMeanY();
+        double mean = rawData.getAvarage();
         double max = rawData.getMaxY();
         double min = rawData.getMinY();
         double stddev = rawData.getStddev();
@@ -155,10 +158,10 @@ public class BasicOperations {
         downsampled.setLabel("downsampled_10x");
 
         System.out.println("Downsample by factor " + downsampleFactor + ":");
-        System.out.println("  Original length: " + rawData.getLength());
-        System.out.println("  Downsampled length: " + downsampled.getLength());
-        System.out.println("  Original mean: " + String.format("%.2f", rawData.getMeanY()));
-        System.out.println("  Downsampled mean: " + String.format("%.2f", downsampled.getMeanY()));
+        System.out.println("  Original length: " + rawData.yValues.size());
+        System.out.println("  Downsampled length: " + downsampled.yValues.size());
+        System.out.println("  Original mean: " + String.format("%.2f", rawData.getAvarage()));
+        System.out.println("  Downsampled mean: " + String.format("%.2f", downsampled.getAvarage()));
         System.out.println("  (Mean should be similar)");
         System.out.println();
 
@@ -180,11 +183,11 @@ public class BasicOperations {
         combined.setLabel("combined_series");
 
         System.out.println("Combining two time series (addition):");
-        System.out.println("  Series 1 mean: " + String.format("%.2f", ts1.getMeanY()));
-        System.out.println("  Series 2 mean: " + String.format("%.2f", ts2.getMeanY()));
-        System.out.println("  Combined mean: " + String.format("%.2f", combined.getMeanY()));
+        System.out.println("  Series 1 mean: " + String.format("%.2f", ts1.getAvarage()));
+        System.out.println("  Series 2 mean: " + String.format("%.2f", ts2.getAvarage()));
+        System.out.println("  Combined mean: " + String.format("%.2f", combined.getAvarage()));
         System.out.println("  Expected mean: " + String.format("%.2f",
-                          ts1.getMeanY() + ts2.getMeanY()));
+                          ts1.getAvarage() + ts2.getAvarage()));
         System.out.println();
 
         // =====================================================
@@ -225,10 +228,10 @@ public class BasicOperations {
         new java.io.File(outputDir).mkdirs();
 
         // Export various transformations for comparison
-        rawData.writeToFile(outputDir + "original.csv", ",");
-        normalized.writeToFile(outputDir + "normalized.csv", ",");
-        scaled.writeToFile(outputDir + "scaled.csv", ",");
-        downsampled.writeToFile(outputDir + "downsampled.csv", ",");
+        rawData.writeToFile(new File(outputDir + "original.csv"), ',');
+        normalized.writeToFile(new File(outputDir + "normalized.csv"), ',');
+        scaled.writeToFile(new File(outputDir + "scaled.csv"), ',');
+        downsampled.writeToFile(new File(outputDir + "downsampled.csv"), ',');
 
         System.out.println("Exported time series to: " + outputDir);
         System.out.println("  - original.csv");

--- a/opentsx-core/src/main/java/org/opentsx/demo/onboarding/SimpleTimeSeriesCreation.java
+++ b/opentsx-core/src/main/java/org/opentsx/demo/onboarding/SimpleTimeSeriesCreation.java
@@ -1,8 +1,10 @@
 package org.opentsx.demo.onboarding;
 
 import org.opentsx.data.generator.RNGWrapper;
+import org.opentsx.data.loader.MessreihenLoader;
 import org.opentsx.data.series.TimeSeriesObject;
 
+import java.io.File;
 import java.io.IOException;
 
 /**
@@ -56,9 +58,9 @@ public class SimpleTimeSeriesCreation {
         ts.addValuePair(currentTime + 4000, 22.9);
 
         System.out.println("Created time series: " + ts.getLabel());
-        System.out.println("Number of data points: " + ts.getLength());
-        System.out.println("First value: " + ts.getValueAt(0));
-        System.out.println("Last value: " + ts.getValueAt(ts.getLength() - 1));
+        System.out.println("Number of data points: " + ts.yValues.size());
+        System.out.println("First value: " + ts.yValues.elementAt(0));
+        System.out.println("Last value: " + ts.yValues.elementAt(ts.yValues.size() - 1));
         System.out.println();
 
         // =====================================================
@@ -72,9 +74,9 @@ public class SimpleTimeSeriesCreation {
         gaussianTS.setLabel("gaussian_distribution");
 
         System.out.println("Generated Gaussian time series:");
-        System.out.println("  Length: " + gaussianTS.getLength());
+        System.out.println("  Length: " + gaussianTS.yValues.size());
         System.out.println("  Expected mean: 10.0");
-        System.out.println("  Actual mean: " + String.format("%.2f", gaussianTS.getMeanY()));
+        System.out.println("  Actual mean: " + String.format("%.2f", gaussianTS.getAvarage()));
         System.out.println("  Expected std dev: 1.5");
         System.out.println("  Actual std dev: " + String.format("%.2f", gaussianTS.getStddev()));
         System.out.println();
@@ -86,8 +88,8 @@ public class SimpleTimeSeriesCreation {
         System.out.println("-------------------------------------");
 
         System.out.println("Statistics for: " + gaussianTS.getLabel());
-        System.out.println("  Length: " + gaussianTS.getLength());
-        System.out.println("  Mean: " + String.format("%.4f", gaussianTS.getMeanY()));
+        System.out.println("  Length: " + gaussianTS.yValues.size());
+        System.out.println("  Mean: " + String.format("%.4f", gaussianTS.getAvarage()));
         System.out.println("  Std Dev: " + String.format("%.4f", gaussianTS.getStddev()));
         System.out.println("  Min: " + String.format("%.4f", gaussianTS.getMinY()));
         System.out.println("  Max: " + String.format("%.4f", gaussianTS.getMaxY()));
@@ -109,12 +111,12 @@ public class SimpleTimeSeriesCreation {
 
         // Export as tab-separated values
         String tsvFile = outputDir + "gaussian_ts.tsv";
-        gaussianTS.writeToFile(tsvFile, "\t");
+        gaussianTS.writeToFile(new File(tsvFile), '\t');
         System.out.println("Exported to TSV: " + tsvFile);
 
         // Export as comma-separated values
         String csvFile = outputDir + "gaussian_ts.csv";
-        gaussianTS.writeToFile(csvFile, ",");
+        gaussianTS.writeToFile(new File(csvFile), ',');
         System.out.println("Exported to CSV: " + csvFile);
 
         System.out.println();
@@ -125,17 +127,19 @@ public class SimpleTimeSeriesCreation {
         System.out.println("TASK 5: Load time series from file");
         System.out.println("----------------------------------");
 
-        TimeSeriesObject loaded = TimeSeriesObject.loadFromFile(new java.io.File(csvFile));
+        MessreihenLoader loader = MessreihenLoader.getLoader();
+        loader.delim = ",";
+        TimeSeriesObject loaded = loader.loadMessreihe_2(new File(csvFile), 1, 2);
         loaded.setLabel("loaded_from_csv");
 
         System.out.println("Loaded time series: " + loaded.getLabel());
-        System.out.println("  Length: " + loaded.getLength());
-        System.out.println("  Mean: " + String.format("%.4f", loaded.getMeanY()));
+        System.out.println("  Length: " + loaded.yValues.size());
+        System.out.println("  Mean: " + String.format("%.4f", loaded.getAvarage()));
         System.out.println("  Std Dev: " + String.format("%.4f", loaded.getStddev()));
         System.out.println();
 
         // Verify data integrity
-        boolean dataMatches = Math.abs(gaussianTS.getMeanY() - loaded.getMeanY()) < 0.001;
+        boolean dataMatches = Math.abs(gaussianTS.getAvarage() - loaded.getAvarage()) < 0.001;
         System.out.println("Data integrity check: " + (dataMatches ? "PASSED ✓" : "FAILED ✗"));
         System.out.println();
 
@@ -158,9 +162,9 @@ public class SimpleTimeSeriesCreation {
 
         System.out.println("Created multiple distributions:");
         System.out.println("  1. " + uniformTS.getLabel() + " - Mean: " +
-                          String.format("%.2f", uniformTS.getMeanY()));
+                          String.format("%.2f", uniformTS.getAvarage()));
         System.out.println("  2. " + highMean.getLabel() + " - Mean: " +
-                          String.format("%.2f", highMean.getMeanY()));
+                          String.format("%.2f", highMean.getAvarage()));
         System.out.println("  3. " + lowVariance.getLabel() + " - Std Dev: " +
                           String.format("%.2f", lowVariance.getStddev()));
         System.out.println();

--- a/opentsx-core/src/main/java/org/opentsx/demo/onboarding/TimeSeriesAnalysis.java
+++ b/opentsx-core/src/main/java/org/opentsx/demo/onboarding/TimeSeriesAnalysis.java
@@ -3,6 +3,7 @@ package org.opentsx.demo.onboarding;
 import org.opentsx.data.generator.RNGWrapper;
 import org.opentsx.data.series.TimeSeriesObject;
 
+import java.io.File;
 import java.io.IOException;
 
 /**
@@ -52,12 +53,12 @@ public class TimeSeriesAnalysis {
         for (int i = 0; i < 500; i++) {
             // Linear trend + Gaussian noise
             double trendValue = 10.0 + 0.05 * i;
-            double noise = RNGWrapper.getGaussianRandomValue(0.0, 2.0);
+            double noise = RNGWrapper.getStdRandomGaussian(0.0, 2.0);
             trendSeries.addValuePair(i, trendValue + noise);
         }
 
         System.out.println("Created time series with linear trend:");
-        System.out.println("  Length: " + trendSeries.getLength());
+        System.out.println("  Length: " + trendSeries.yValues.size());
         System.out.println("  Start value (avg): " + String.format("%.2f",
                           average(trendSeries, 0, 10)));
         System.out.println("  End value (avg): " + String.format("%.2f",
@@ -80,8 +81,8 @@ public class TimeSeriesAnalysis {
             smoothed.setLabel("smoothed_window_" + window);
 
             System.out.println("Window size " + window + ":");
-            System.out.println("  Original length: " + trendSeries.getLength());
-            System.out.println("  Smoothed length: " + smoothed.getLength());
+            System.out.println("  Original length: " + trendSeries.yValues.size());
+            System.out.println("  Smoothed length: " + smoothed.yValues.size());
             System.out.println("  Original std dev: " + String.format("%.4f",
                               trendSeries.getStddev()));
             System.out.println("  Smoothed std dev: " + String.format("%.4f",
@@ -113,16 +114,16 @@ public class TimeSeriesAnalysis {
         TimeSeriesObject detrended = new TimeSeriesObject();
         detrended.setLabel("detrended_series");
 
-        for (int i = 0; i < trendSeries.getLength(); i++) {
-            double originalValue = trendSeries.getValueAt(i);
+        for (int i = 0; i < trendSeries.yValues.size(); i++) {
+            double originalValue = (Double)trendSeries.yValues.elementAt(i);
             double trendValue = firstAvg + estimatedSlope * i;
             double detrendedValue = originalValue - trendValue;
             detrended.addValuePair(i, detrendedValue);
         }
 
         System.out.println("Detrending results:");
-        System.out.println("  Original mean: " + String.format("%.2f", trendSeries.getMeanY()));
-        System.out.println("  Detrended mean: " + String.format("%.2f", detrended.getMeanY()));
+        System.out.println("  Original mean: " + String.format("%.2f", trendSeries.getAvarage()));
+        System.out.println("  Detrended mean: " + String.format("%.2f", detrended.getAvarage()));
         System.out.println("  (Should be close to 0)");
         System.out.println();
 
@@ -139,13 +140,13 @@ public class TimeSeriesAnalysis {
         int period = 24; // Daily pattern
         for (int i = 0; i < 500; i++) {
             double value = 10.0 + 5.0 * Math.sin(2 * Math.PI * i / period);
-            double noise = RNGWrapper.getGaussianRandomValue(0.0, 1.0);
+            double noise = RNGWrapper.getStdRandomGaussian(0.0, 1.0);
             periodic.addValuePair(i, value + noise);
         }
 
         System.out.println("Created periodic time series:");
         System.out.println("  Period: " + period + " points");
-        System.out.println("  Length: " + periodic.getLength());
+        System.out.println("  Length: " + periodic.yValues.size());
         System.out.println();
 
         // Simple autocorrelation at lag = period
@@ -179,9 +180,9 @@ public class TimeSeriesAnalysis {
         for (int i = 0; i < 300; i++) {
             double value;
             if (i < 150) {
-                value = RNGWrapper.getGaussianRandomValue(10.0, 2.0);
+                value = RNGWrapper.getStdRandomGaussian(10.0, 2.0);
             } else {
-                value = RNGWrapper.getGaussianRandomValue(20.0, 2.0);
+                value = RNGWrapper.getStdRandomGaussian(20.0, 2.0);
             }
             regimeChange.addValuePair(i, value);
         }
@@ -194,7 +195,7 @@ public class TimeSeriesAnalysis {
         double maxDiff = 0;
         int changePoint = 0;
 
-        for (int i = windowSize; i < regimeChange.getLength() - windowSize; i++) {
+        for (int i = windowSize; i < regimeChange.yValues.size() - windowSize; i++) {
             double beforeMean = average(regimeChange, i - windowSize, i);
             double afterMean = average(regimeChange, i, i + windowSize);
             double diff = Math.abs(afterMean - beforeMean);
@@ -221,10 +222,10 @@ public class TimeSeriesAnalysis {
         new java.io.File(outputDir).mkdirs();
 
         // Export various series for external analysis
-        trendSeries.writeToFile(outputDir + "trend_series.csv", ",");
-        detrended.writeToFile(outputDir + "detrended.csv", ",");
-        periodic.writeToFile(outputDir + "periodic.csv", ",");
-        regimeChange.writeToFile(outputDir + "regime_change.csv", ",");
+        trendSeries.writeToFile(new File(outputDir + "trend_series.csv"), ',');
+        detrended.writeToFile(new File(outputDir + "detrended.csv"), ',');
+        periodic.writeToFile(new File(outputDir + "periodic.csv"), ',');
+        regimeChange.writeToFile(new File(outputDir + "regime_change.csv"), ',');
 
         System.out.println("Exported time series to: " + outputDir);
         System.out.println("  - trend_series.csv (for trend analysis)");
@@ -273,8 +274,8 @@ public class TimeSeriesAnalysis {
     private static double average(TimeSeriesObject ts, int start, int end) {
         double sum = 0;
         int count = 0;
-        for (int i = start; i < end && i < ts.getLength(); i++) {
-            sum += ts.getValueAt(i);
+        for (int i = start; i < end && i < ts.yValues.size(); i++) {
+            sum += (Double)ts.yValues.elementAt(i);
             count++;
         }
         return count > 0 ? sum / count : 0.0;
@@ -284,14 +285,14 @@ public class TimeSeriesAnalysis {
      * Simple autocorrelation calculation at a specific lag
      */
     private static double simpleAutocorrelation(TimeSeriesObject ts, int lag) {
-        double mean = ts.getMeanY();
+        double mean = ts.getAvarage();
         double variance = ts.getStddev() * ts.getStddev();
 
         double sum = 0;
         int count = 0;
 
-        for (int i = 0; i < ts.getLength() - lag; i++) {
-            sum += (ts.getValueAt(i) - mean) * (ts.getValueAt(i + lag) - mean);
+        for (int i = 0; i < ts.yValues.size() - lag; i++) {
+            sum += ((Double)ts.yValues.elementAt(i) - mean) * ((Double)ts.yValues.elementAt(i + lag) - mean);
             count++;
         }
 
@@ -303,8 +304,8 @@ public class TimeSeriesAnalysis {
      */
     private static void printStatisticalSummary(TimeSeriesObject ts) {
         System.out.println("Statistical Summary for: " + ts.getLabel());
-        System.out.println("  Count: " + ts.getLength());
-        System.out.println("  Mean: " + String.format("%.4f", ts.getMeanY()));
+        System.out.println("  Count: " + ts.yValues.size());
+        System.out.println("  Mean: " + String.format("%.4f", ts.getAvarage()));
         System.out.println("  Std Dev: " + String.format("%.4f", ts.getStddev()));
         System.out.println("  Min: " + String.format("%.4f", ts.getMinY()));
         System.out.println("  Max: " + String.format("%.4f", ts.getMaxY()));
@@ -319,6 +320,6 @@ public class TimeSeriesAnalysis {
         System.out.println("  50th percentile (approx): " + String.format("%.4f", median));
         System.out.println("  75th percentile (approx): " + String.format("%.4f", q3));
         System.out.println("  Coefficient of Variation: " +
-                          String.format("%.4f", ts.getStddev() / ts.getMeanY()));
+                          String.format("%.4f", ts.getStddev() / ts.getAvarage()));
     }
 }

--- a/opentsx-core/src/main/java/org/opentsx/demo/onboarding/TimeSeriesOperations.java
+++ b/opentsx-core/src/main/java/org/opentsx/demo/onboarding/TimeSeriesOperations.java
@@ -3,6 +3,7 @@ package org.opentsx.demo.onboarding;
 import org.opentsx.data.generator.RNGWrapper;
 import org.opentsx.data.series.TimeSeriesObject;
 
+import java.io.File;
 import java.io.IOException;
 
 /**
@@ -56,8 +57,8 @@ public class TimeSeriesOperations {
         System.out.println("  TimeSeriesObject ts = TimeSeriesObject.getGaussianDistribution(");
         System.out.println("      1000, 10.0, 1.5);");
         System.out.println("\nResult:");
-        System.out.println("  Length: " + ts.getLength());
-        System.out.println("  Mean: " + String.format("%.4f", ts.getMeanY()) + " (expected: 10.0)");
+        System.out.println("  Length: " + ts.yValues.size());
+        System.out.println("  Mean: " + String.format("%.4f", ts.getAvarage()) + " (expected: 10.0)");
         System.out.println("  Std Dev: " + String.format("%.4f", ts.getStddev()) + " (expected: 1.5)");
         System.out.println();
 
@@ -69,19 +70,19 @@ public class TimeSeriesOperations {
 
         System.out.println("Operation      | R             | Python        | OpenTSx");
         System.out.println("---------------|---------------|---------------|------------------");
-        System.out.println("Mean           | mean(ts)      | ts.mean()     | ts.getMeanY()");
+        System.out.println("Mean           | mean(ts)      | ts.mean()     | ts.getAvarage()");
         System.out.println("Std Dev        | sd(ts)        | ts.std()      | ts.getStddev()");
         System.out.println("Min            | min(ts)       | ts.min()      | ts.getMinY()");
         System.out.println("Max            | max(ts)       | ts.max()      | ts.getMaxY()");
-        System.out.println("Length         | length(ts)    | len(ts)       | ts.getLength()");
+        System.out.println("Length         | length(ts)    | len(ts)       | ts.yValues.size()");
         System.out.println();
 
         System.out.println("Computed values:");
-        System.out.println("  Mean:    " + String.format("%.4f", ts.getMeanY()));
+        System.out.println("  Mean:    " + String.format("%.4f", ts.getAvarage()));
         System.out.println("  Std Dev: " + String.format("%.4f", ts.getStddev()));
         System.out.println("  Min:     " + String.format("%.4f", ts.getMinY()));
         System.out.println("  Max:     " + String.format("%.4f", ts.getMaxY()));
-        System.out.println("  Length:  " + ts.getLength());
+        System.out.println("  Length:  " + ts.yValues.size());
         System.out.println();
 
         // =====================================================
@@ -98,8 +99,8 @@ public class TimeSeriesOperations {
 
         System.out.println("  TimeSeriesObject normalized = ts.normalizeToStdevIsOne();");
         System.out.println("\nResult:");
-        System.out.println("  Original mean: " + String.format("%.4f", ts.getMeanY()));
-        System.out.println("  Normalized mean: " + String.format("%.4f", normalized.getMeanY()) +
+        System.out.println("  Original mean: " + String.format("%.4f", ts.getAvarage()));
+        System.out.println("  Normalized mean: " + String.format("%.4f", normalized.getAvarage()) +
                           " (should be ~0)");
         System.out.println("  Original std dev: " + String.format("%.4f", ts.getStddev()));
         System.out.println("  Normalized std dev: " + String.format("%.4f", normalized.getStddev()) +
@@ -118,7 +119,7 @@ public class TimeSeriesOperations {
         // Create series with trend for better demonstration
         TimeSeriesObject trendData = new TimeSeriesObject();
         for (int i = 0; i < 100; i++) {
-            double value = 10.0 + 0.5 * i + RNGWrapper.getGaussianRandomValue(0, 1);
+            double value = 10.0 + 0.5 * i + RNGWrapper.getStdRandomGaussian(0, 1);
             trendData.addValuePair(i, value);
         }
         trendData.setLabel("trend_data");
@@ -126,21 +127,21 @@ public class TimeSeriesOperations {
         // Difference to remove trend
         TimeSeriesObject differenced = new TimeSeriesObject();
         differenced.setLabel("differenced");
-        for (int i = 1; i < trendData.getLength(); i++) {
-            double diff = trendData.getValueAt(i) - trendData.getValueAt(i - 1);
+        for (int i = 1; i < trendData.yValues.size(); i++) {
+            double diff = trendData(Double).yValues.elementAt(i) - trendData(Double).yValues.elementAt(i - 1);
             differenced.addValuePair(i, diff);
         }
 
         System.out.println("  // Manual differencing");
-        System.out.println("  for (int i = 1; i < ts.getLength(); i++) {");
-        System.out.println("      double diff = ts.getValueAt(i) - ts.getValueAt(i-1);");
+        System.out.println("  for (int i = 1; i < ts.yValues.size(); i++) {");
+        System.out.println("      double diff = ts(Double).yValues.elementAt(i) - ts(Double).yValues.elementAt(i-1);");
         System.out.println("      differenced.addValuePair(i, diff);");
         System.out.println("  }");
         System.out.println("\nResult:");
-        System.out.println("  Original length: " + trendData.getLength());
-        System.out.println("  Differenced length: " + differenced.getLength());
-        System.out.println("  Original mean: " + String.format("%.2f", trendData.getMeanY()));
-        System.out.println("  Differenced mean: " + String.format("%.2f", differenced.getMeanY()));
+        System.out.println("  Original length: " + trendData.yValues.size());
+        System.out.println("  Differenced length: " + differenced.yValues.size());
+        System.out.println("  Original mean: " + String.format("%.2f", trendData.getAvarage()));
+        System.out.println("  Differenced mean: " + String.format("%.2f", differenced.getAvarage()));
         System.out.println("  (Trend removed: mean ~0.5)");
         System.out.println();
 
@@ -181,15 +182,15 @@ public class TimeSeriesOperations {
         // Simple autocorrelation implementation
         int maxLag = 20;
         double[] acf = new double[maxLag + 1];
-        double mean = ts.getMeanY();
+        double mean = ts.getAvarage();
         double variance = ts.getStddev() * ts.getStddev();
 
         for (int lag = 0; lag <= maxLag; lag++) {
             double sum = 0;
             int count = 0;
 
-            for (int i = 0; i < ts.getLength() - lag; i++) {
-                sum += (ts.getValueAt(i) - mean) * (ts.getValueAt(i + lag) - mean);
+            for (int i = 0; i < ts.yValues.size() - lag; i++) {
+                sum += (ts(Double).yValues.elementAt(i) - mean) * (ts(Double).yValues.elementAt(i + lag) - mean);
                 count++;
             }
 
@@ -224,12 +225,12 @@ public class TimeSeriesOperations {
         System.out.println("  int factor = 5;");
         System.out.println("  TimeSeriesObject downsampled = ts.setBinningX_average(factor);");
         System.out.println("\nResult:");
-        System.out.println("  Original length: " + ts.getLength());
-        System.out.println("  Downsampled length: " + downsampled.getLength());
+        System.out.println("  Original length: " + ts.yValues.size());
+        System.out.println("  Downsampled length: " + downsampled.yValues.size());
         System.out.println("  Reduction factor: " + String.format("%.1fx",
-                          (double) ts.getLength() / downsampled.getLength()));
+                          (double) ts.yValues.size() / downsampled.yValues.size()));
         System.out.println("  Mean preserved: " +
-                          Math.abs(ts.getMeanY() - downsampled.getMeanY()) < 0.1);
+                          Math.abs(ts.getAvarage() - downsampled.getAvarage()) < 0.1);
         System.out.println();
 
         // =====================================================
@@ -251,11 +252,11 @@ public class TimeSeriesOperations {
 
         System.out.println("  TimeSeriesObject combined = ts1.add(ts2);");
         System.out.println("\nResult:");
-        System.out.println("  Series 1 mean: " + String.format("%.2f", ts1.getMeanY()));
-        System.out.println("  Series 2 mean: " + String.format("%.2f", ts2.getMeanY()));
-        System.out.println("  Combined mean: " + String.format("%.2f", combined.getMeanY()));
+        System.out.println("  Series 1 mean: " + String.format("%.2f", ts1.getAvarage()));
+        System.out.println("  Series 2 mean: " + String.format("%.2f", ts2.getAvarage()));
+        System.out.println("  Combined mean: " + String.format("%.2f", combined.getAvarage()));
         System.out.println("  Expected mean: " + String.format("%.2f",
-                          ts1.getMeanY() + ts2.getMeanY()));
+                          ts1.getAvarage() + ts2.getAvarage()));
         System.out.println();
 
         // =====================================================
@@ -267,9 +268,9 @@ public class TimeSeriesOperations {
         String outputDir = "data/demo_output/tsx/";
         new java.io.File(outputDir).mkdirs();
 
-        ts.writeToFile(outputDir + "original.csv", ",");
-        normalized.writeToFile(outputDir + "normalized.csv", ",");
-        smoothed.writeToFile(outputDir + "smoothed.csv", ",");
+        ts.writeToFile(new File(outputDir + "original.csv"), ',');
+        normalized.writeToFile(new File(outputDir + "normalized.csv"), ',');
+        smoothed.writeToFile(new File(outputDir + "smoothed.csv"), ',');
 
         System.out.println("Exported to: " + outputDir);
         System.out.println();
@@ -297,7 +298,7 @@ public class TimeSeriesOperations {
         System.out.println("Task              | R                  | Python              | OpenTSx");
         System.out.println("------------------|--------------------|--------------------|------------------------");
         System.out.println("Create TS         | rnorm(n, μ, σ)     | np.random.normal() | getGaussianDistribution()");
-        System.out.println("Mean              | mean(ts)           | ts.mean()          | ts.getMeanY()");
+        System.out.println("Mean              | mean(ts)           | ts.mean()          | ts.getAvarage()");
         System.out.println("Std Dev           | sd(ts)             | ts.std()           | ts.getStddev()");
         System.out.println("Normalize         | scale(ts)          | (ts-μ)/σ           | normalizeToStdevIsOne()");
         System.out.println("Difference        | diff(ts)           | ts.diff()          | manual loop");


### PR DESCRIPTION
Updated all 5 demo files to use correct OpenTSx API methods:
- Replace getMeanY() with getAvarage()
- Replace getLength() with yValues.size()
- Replace getValueAt(i) with (Double)yValues.elementAt(i)
- Replace setValueAt() with yValues.setElementAt()
- Replace RNGWrapper.getGaussianRandomValue() with getStdRandomGaussian()
- Fix writeToFile() to use File parameter instead of String
- Add MessreihenLoader for file loading operations
- Add File import to all demo files

All demo files now compile correctly with the actual TimeSeriesObject API.