### PR TITLE
Fix PDF generation: Switch to xelatex for Unicode support

### DIFF
--- a/bin/build_manual_pdf.sh
+++ b/bin/build_manual_pdf.sh
@@ -33,7 +33,7 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Default settings
-PDF_ENGINE="pdflatex"
+PDF_ENGINE="xelatex"  # Use xelatex for better Unicode support
 OUTPUT_FILE="OpenTSx-Manual.pdf"
 VERBOSE=false
 CHECK_ONLY=false
@@ -252,6 +252,15 @@ PANDOC_ARGS=(
     "--variable" "urlcolor=blue"
     "--variable" "citecolor=blue"
 )
+
+# Add Unicode font support for xelatex/lualatex
+if [ "$PDF_ENGINE" = "xelatex" ] || [ "$PDF_ENGINE" = "lualatex" ]; then
+    PANDOC_ARGS+=(
+        "--variable" "mainfont=DejaVu Serif"
+        "--variable" "sansfont=DejaVu Sans"
+        "--variable" "monofont=DejaVu Sans Mono"
+    )
+fi
 
 if [ "$VERBOSE" = true ]; then
     PANDOC_ARGS+=("--verbose")

--- a/docs/PDF-GENERATION.md
+++ b/docs/PDF-GENERATION.md
@@ -39,7 +39,7 @@ pandoc --version
 
 #### 2. LaTeX Distribution
 
-A LaTeX distribution is required for PDF rendering (pdflatex, xelatex, or lualatex).
+A LaTeX distribution is required for PDF rendering. **XeLaTeX** is the default engine as it provides better Unicode support (required for box-drawing characters and special symbols in the documentation).
 
 **TeXLive (Recommended):**
 
@@ -328,12 +328,20 @@ sudo apt-get install texlive-latex-extra texlive-fonts-extra
 
 ### "Unicode character ... not set up for use with LaTeX"
 
-**Problem:** Special characters require XeLaTeX/LuaLaTeX.
+**Problem:** Special characters (box-drawing characters: ┌, ├, │, └) require XeLaTeX/LuaLaTeX.
+
+**Note:** XeLaTeX is now the default engine (since version 3.0.0) to handle Unicode characters in documentation.
 
 **Solution:**
 ```bash
-# Use XeLaTeX instead of pdflatex
+# XeLaTeX is default, but you can explicitly specify it
 ./bin/build_manual_pdf.sh --engine xelatex
+
+# Or use LuaLaTeX as alternative
+./bin/build_manual_pdf.sh --engine lualatex
+
+# Only use pdflatex if documentation has no Unicode characters
+./bin/build_manual_pdf.sh --engine pdflatex
 ```
 
 ### PDF Generation Fails During Maven Build


### PR DESCRIPTION
Problem:
- PDF generation failed with pdflatex due to Unicode box-drawing characters
- LaTeX Error: Unicode character ┌ (U+250C) not set up for use with LaTeX
- Characters used in ASCII art diagrams in documentation

Solution:
- Switch default PDF engine from pdflatex to xelatex
- Add Unicode font support (DejaVu fonts) for xelatex/lualatex
- Update documentation to explain xelatex as default

Changes:
1. bin/build_manual_pdf.sh:
   - Change PDF_ENGINE default to 'xelatex'
   - Add conditional font configuration for xelatex/lualatex
   - Configure DejaVu font family (Serif, Sans, Sans Mono)

2. docs/PDF-GENERATION.md:
   - Document xelatex as default engine
   - Explain Unicode support requirement
   - Update troubleshooting section with detailed Unicode guidance
   - Add note about when to use pdflatex vs xelatex

Technical Details:
- XeLaTeX provides native Unicode support
- DejaVu fonts include comprehensive Unicode glyphs
- Box-drawing characters (┌├│└) now render correctly
- Maintains backward compatibility (can still use pdflatex via --engine flag)

Testing:
- Build should now succeed: mvn clean package
- PDF will contain properly rendered Unicode diagrams
- Alternative: ./bin/build_manual_pdf.sh (uses xelatex by default)