### PR TITLE
Fix PostgreSQL connection error with database retry logic

### DIFF
--- a/opentsx-saas-backend/app/db/utils.py
+++ b/opentsx-saas-backend/app/db/utils.py
@@ -1,0 +1,46 @@
+"""
+Database connection utilities with retry logic.
+"""
+
+import asyncio
+import logging
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+logger = logging.getLogger(__name__)
+
+
+async def wait_for_db(engine: AsyncEngine, max_retries: int = 30, delay: float = 1.0) -> bool:
+    """
+    Wait for database to be ready with exponential backoff.
+
+    Args:
+        engine: SQLAlchemy async engine
+        max_retries: Maximum number of connection attempts
+        delay: Initial delay between retries in seconds
+
+    Returns:
+        True if connection successful, raises exception otherwise
+    """
+    for attempt in range(max_retries):
+        try:
+            async with engine.begin() as conn:
+                # Simple query to test connection
+                await conn.execute(text("SELECT 1"))
+            logger.info("✅ Database connection established")
+            return True
+
+        except (OperationalError, ConnectionRefusedError, OSError) as e:
+            if attempt < max_retries - 1:
+                wait_time = min(delay * (2 ** attempt), 10)  # Cap at 10 seconds
+                logger.warning(
+                    f"Database not ready (attempt {attempt + 1}/{max_retries}). "
+                    f"Retrying in {wait_time:.1f}s... Error: {str(e)[:100]}"
+                )
+                await asyncio.sleep(wait_time)
+            else:
+                logger.error(f"Failed to connect to database after {max_retries} attempts")
+                raise
+
+    return False

--- a/opentsx-saas-backend/app/main.py
+++ b/opentsx-saas-backend/app/main.py
@@ -22,6 +22,7 @@ from app.db.session import async_engine
 from app.db.base_class import Base
 from app.db.init_db import init_db
 from app.db.session import AsyncSessionLocal
+from app.db.utils import wait_for_db
 
 
 # ==================== Lifespan ====================
@@ -33,6 +34,10 @@ async def lifespan(app: FastAPI):
 
     Handles startup and shutdown events.
     """
+    # Wait for database to be ready
+    print("⏳ Waiting for database connection...")
+    await wait_for_db(async_engine)
+
     # Startup: Create tables and initialize database
     async with async_engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)


### PR DESCRIPTION
Resolves ConnectionRefusedError when backend starts before PostgreSQL is ready.

Changes:
- Add app/db/utils.py with wait_for_db() retry function
- Implement exponential backoff (max 10s delay, 30 retries)
- Integrate retry logic into app/main.py lifespan function
- Backend now waits for database before creating tables

Technical details:
- Uses SQLAlchemy text() for raw SQL queries
- Handles OperationalError, ConnectionRefusedError, OSError
- Provides detailed logging of connection attempts
- Compatible with Docker Compose health checks