### PR TITLE
Fix PostgreSQL health check and add .gitignore

### DIFF
--- a/opentsx-saas-backend/.gitignore
+++ b/opentsx-saas-backend/.gitignore
@@ -1,0 +1,47 @@
+# Environment variables
+.env
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+venv/
+ENV/
+env/
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# Database
+*.db
+*.sqlite3

--- a/opentsx-saas-backend/docker-compose.yml
+++ b/opentsx-saas-backend/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     networks:
       - opentsx-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-opentsx_user} -d ${POSTGRES_DB:-opentsx}"]
+      test: ["CMD-SHELL", "pg_isready -U opentsx_user -d opentsx"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
The Docker Compose health check was using incorrect syntax for environment variables, causing the check to fail and preventing proper startup sequencing.

Changes:
- Fix postgres health check: use hardcoded values instead of ${VAR:-default}
- Add .gitignore to protect sensitive .env file
- .env file with generated SECRET_KEY (not committed, gitignored)

The issue: Docker Compose healthcheck doesn't support ${VAR:-default} syntax in test commands. Variables must be either $VAR or hardcoded.

This fixes the PostgreSQL "Connection refused" issue by ensuring the health check actually works and PostgreSQL is truly ready before backend starts.