### PR TITLE
Improve PostgreSQL health check with actual connection test

### DIFF
--- a/opentsx-saas-backend/Dockerfile
+++ b/opentsx-saas-backend/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y \
     gcc \
     postgresql-client \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies

--- a/opentsx-saas-backend/docker-compose.yml
+++ b/opentsx-saas-backend/docker-compose.yml
@@ -18,10 +18,11 @@ services:
     networks:
       - opentsx-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U opentsx_user -d opentsx"]
-      interval: 10s
+      test: ["CMD-SHELL", "pg_isready -U opentsx_user -d opentsx && PGPASSWORD=change_this_password psql -U opentsx_user -d opentsx -c 'SELECT 1' >/dev/null 2>&1"]
+      interval: 5s
       timeout: 5s
-      retries: 5
+      retries: 10
+      start_period: 10s
 
   # Redis Cache
   redis:
@@ -83,11 +84,11 @@ services:
     volumes:
       - ./app:/app/app  # Mount for development hot-reload
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 40s
+      start_period: 60s
 
 networks:
   opentsx-network:


### PR DESCRIPTION
The previous health check only used pg_isready which doesn't test authentication. This caused the backend to start before PostgreSQL was fully initialized and ready to accept authenticated connections.

Changes:
- PostgreSQL health check now tests actual SELECT query with auth
- Reduced interval to 5s and increased retries to 10
- Added start_period: 10s for proper initialization time
- Fixed backend health check endpoint: /health (not /api/v1/health)
- Increased backend start_period to 60s
- Added curl to Dockerfile for health check support

This ensures PostgreSQL can execute queries before backend starts.