### PR TITLE
Fix Pydantic validation errors causing backend restart loop

### DIFF
--- a/opentsx-saas-backend/app/core/config.py
+++ b/opentsx-saas-backend/app/core/config.py
@@ -1,7 +1,7 @@
 """Application configuration."""
 
 from typing import Optional
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import validator
 
 
@@ -72,9 +72,11 @@ class Settings(BaseSettings):
         """Get Redis URL."""
         return f"redis://{self.REDIS_HOST}:{self.REDIS_PORT}/{self.REDIS_DB}"
 
-    class Config:
-        case_sensitive = True
-        env_file = ".env"
+    model_config = SettingsConfigDict(
+        case_sensitive=True,
+        env_file=".env",
+        extra="ignore"  # Ignore extra environment variables from docker-compose
+    )
 
 
 settings = Settings()

--- a/opentsx-saas-backend/docker-compose.yml
+++ b/opentsx-saas-backend/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # PostgreSQL Database
   postgres:
@@ -53,18 +51,23 @@ services:
       # Application
       PROJECT_NAME: ${PROJECT_NAME:-OpenTSx SaaS Platform}
       API_V1_STR: ${API_V1_STR:-/api/v1}
-      DEBUG: ${DEBUG:-False}
 
       # Security
       SECRET_KEY: ${SECRET_KEY:-your-secret-key-change-this-in-production}
       ALGORITHM: ${ALGORITHM:-HS256}
       ACCESS_TOKEN_EXPIRE_MINUTES: ${ACCESS_TOKEN_EXPIRE_MINUTES:-30}
 
-      # Database
-      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-opentsx_user}:${POSTGRES_PASSWORD:-change_this_password}@postgres:5432/${POSTGRES_DB:-opentsx}
+      # Database - must match Settings field names
+      POSTGRES_SERVER: postgres
+      POSTGRES_USER: ${POSTGRES_USER:-opentsx_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-change_this_password}
+      POSTGRES_DB: ${POSTGRES_DB:-opentsx}
+      POSTGRES_PORT: 5432
 
-      # Redis
-      REDIS_URL: redis://:${REDIS_PASSWORD:-change_this_redis_password}@redis:6379/0
+      # Redis - must match Settings field names
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_DB: 0
 
       # First Superuser
       FIRST_SUPERUSER_EMAIL: ${FIRST_SUPERUSER_EMAIL:-admin@opentsx.com}


### PR DESCRIPTION
The backend was crashing on startup due to Pydantic ValidationError. The Settings class didn't allow extra environment variables, but docker-compose was passing DATABASE_URL, REDIS_URL, DEBUG, etc.

Root cause:
- Settings class expects individual fields (POSTGRES_SERVER, POSTGRES_USER, etc.)
- docker-compose was passing combined URLs (DATABASE_URL, REDIS_URL)
- Pydantic v2 defaults to forbidding extra fields, causing ValidationError
- This crashed the app, triggering infinite restart loop

Fixes:
1. Updated Settings to use Pydantic v2 model_config syntax
2. Added extra="ignore" to allow docker-compose extra env vars
3. Fixed docker-compose.yml to pass correct environment variable names:
   - POSTGRES_SERVER=postgres (instead of in DATABASE_URL)
   - POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB, POSTGRES_PORT
   - REDIS_HOST=redis, REDIS_PORT, REDIS_DB (instead of REDIS_URL)
4. Removed obsolete 'version' attribute from docker-compose.yml
5. Removed DEBUG and BACKEND_PORT env vars (not used by Settings)

The Settings class constructs database_url and redis_url as properties from individual fields, so we pass the individual fields instead.