### PR TITLE
Add greenlet dependency for SQLAlchemy async support

### DIFF
--- a/opentsx-saas-backend/requirements.txt
+++ b/opentsx-saas-backend/requirements.txt
@@ -8,6 +8,7 @@ sqlalchemy==2.0.25
 alembic==1.13.1
 psycopg2-binary==2.9.9
 asyncpg==0.29.0
+greenlet==3.0.3  # Required for SQLAlchemy async operations
 
 # Authentication
 python-jose[cryptography]==3.3.0


### PR DESCRIPTION
The greenlet library is required for SQLAlchemy's async operations but was missing from requirements.txt, causing startup failures.

Error: ValueError: the greenlet library is required to use this function.
       No module named 'greenlet'

Added greenlet==3.0.3 to fix async database operations.