### PR TITLE
Fix SQLAlchemy model relationship resolution

### DIFF
--- a/opentsx-saas-backend/app/db/base.py
+++ b/opentsx-saas-backend/app/db/base.py
@@ -1,0 +1,9 @@
+"""Import all models here to ensure SQLAlchemy can resolve relationships."""
+
+from app.db.base_class import Base  # noqa
+
+# Import all models so they are registered with SQLAlchemy
+from app.models.user import User, Organization  # noqa
+from app.models.flow import Flow  # noqa
+
+__all__ = ["Base", "User", "Organization", "Flow"]

--- a/opentsx-saas-backend/app/main.py
+++ b/opentsx-saas-backend/app/main.py
@@ -19,7 +19,7 @@ import uvicorn
 from app.core.config import settings
 from app.api import auth
 from app.db.session import async_engine
-from app.db.base_class import Base
+from app.db.base import Base  # Import from base.py to ensure all models are loaded
 from app.db.init_db import init_db
 from app.db.session import AsyncSessionLocal
 from app.db.utils import wait_for_db

--- a/opentsx-saas-backend/app/models/__init__.py
+++ b/opentsx-saas-backend/app/models/__init__.py
@@ -1,0 +1,7 @@
+"""Database models."""
+
+# Import all models here so SQLAlchemy can resolve relationships
+from app.models.user import User
+from app.models.flow import Flow
+
+__all__ = ["User", "Flow"]


### PR DESCRIPTION
Fixed InvalidRequestError when initializing User mapper - 'Flow' model could not be located due to missing model imports.

Issue:
- SQLAlchemy couldn't resolve 'Flow' relationship in User model
- Models were not imported in a centralized location
- String-based relationships require all models to be imported

Solution:
- Created app/models/__init__.py to import all models
- Created app/db/base.py that imports Base and all models
- Updated app/main.py to import from base.py instead of base_class.py
- This ensures all models are registered before metadata.create_all()

This follows SQLAlchemy best practices for model organization.